### PR TITLE
fix: unify DELETE endpoint to /mcp/v1/messages per MCP spec and bump …

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Server will start on `http://127.0.0.1:8000` with endpoints:
 - `GET /health` - Health check
 - `POST /mcp/v1/messages` - Send JSON-RPC messages
 - `GET /mcp/v1/messages` - Subscribe to SSE events
-- `DELETE /mcp/v1/sessions` - Close session
+- `DELETE /mcp/v1/messages` - Close session
 
 #### 3. Test HTTP Server
 ```bash

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -182,7 +182,7 @@ python -m mcp_image_server
 - `GET /health` - 健康检查
 - `POST /mcp/v1/messages` - 发送 JSON-RPC 消息
 - `GET /mcp/v1/messages` - 订阅 SSE 事件
-- `DELETE /mcp/v1/sessions` - 关闭会话
+- `DELETE /mcp/v1/messages` - 关闭会话
 
 #### 3. 测试 HTTP 服务器
 ```bash

--- a/docs/HTTP_TRANSPORT_GUIDE.md
+++ b/docs/HTTP_TRANSPORT_GUIDE.md
@@ -246,7 +246,7 @@ OPENAI_API_KEY=${OPENAI_API_KEY}  # 从密钥管理器读取
 | `GET` | `/health` | 健康检查 |
 | `POST` | `/mcp/v1/messages` | 发送 JSON-RPC 消息 |
 | `GET` | `/mcp/v1/messages` | 订阅 SSE 事件流 |
-| `DELETE` | `/mcp/v1/sessions` | 删除会话 |
+| `DELETE` | `/mcp/v1/messages` | 删除会话 |
 
 ### 1. 健康检查
 
@@ -648,7 +648,7 @@ data: {"type":"keepalive"}
 
 ### 5. 会话删除
 
-#### DELETE /mcp/v1/sessions
+#### DELETE /mcp/v1/messages
 
 删除当前会话。
 

--- a/examples/example_http_client.py
+++ b/examples/example_http_client.py
@@ -280,7 +280,7 @@ class MCPHTTPClient:
         print(f"\n🔒 关闭连接...")
 
         response = await client.delete(
-            f"{self.base_url}/mcp/v1/sessions",
+            f"{self.base_url}/mcp/v1/messages",
             headers=self._get_headers()
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "hunyuan-image-mcp"
 version = "0.2.0"
 description = "Multi-API图像生成MCP服务器，支持stdio和HTTP传输"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 license = {text = "MIT"}
 dependencies = [
     "tencentcloud-sdk-python>=3.0.0",

--- a/src/mcp_image_server/transports/http.py
+++ b/src/mcp_image_server/transports/http.py
@@ -4,7 +4,7 @@ HTTP transport layer for MCP server.
 This module implements the MCP Streamable HTTP transport protocol:
 - POST /mcp/v1/messages - Send JSON-RPC messages
 - GET  /mcp/v1/messages - Subscribe to SSE event stream
-- DELETE /mcp/v1/sessions - Terminate session
+- DELETE /mcp/v1/messages - Terminate session
 """
 
 import asyncio
@@ -347,7 +347,7 @@ class MCPHTTPHandler:
 
     async def handle_delete(self, request: Request) -> Response:
         """
-        Handle DELETE /mcp/v1/sessions - Terminate session.
+        Handle DELETE /mcp/v1/messages - Terminate session.
 
         Args:
             request: HTTP DELETE request

--- a/src/mcp_image_server/transports/http_server.py
+++ b/src/mcp_image_server/transports/http_server.py
@@ -592,7 +592,7 @@ You can specify provider:style or provider:resolution format, or let the system 
         routes = [
             Route("/mcp/v1/messages", self.http_handler.handle_post, methods=["POST"]),
             Route("/mcp/v1/messages", self.http_handler.handle_get, methods=["GET"]),
-            Route("/mcp/v1/sessions", self.http_handler.handle_delete, methods=["DELETE"]),
+            Route("/mcp/v1/messages", self.http_handler.handle_delete, methods=["DELETE"]),
             Route("/health", health_check, methods=["GET"]),
         ]
 

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -166,7 +166,7 @@ async def test_http_server():
                 # Test 7: Delete session
                 print("\n[7] Testing session deletion...")
                 response = await client.delete(
-                    f"{base_url}/mcp/v1/sessions",
+                    f"{base_url}/mcp/v1/messages",
                     headers=headers
                 )
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -342,7 +342,7 @@ class MCPServerTester:
 
         try:
             response = await client.delete(
-                f"{self.base_url}/mcp/v1/sessions",
+                f"{self.base_url}/mcp/v1/messages",
                 headers=self._get_headers()
             )
 


### PR DESCRIPTION
requires-python to >=3.10 and unify DELETE endpoint to /mcp/v1/messages per MCP spec 