### PR TITLE
feat(http): return accessible image URLs and serve /images

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,6 +55,10 @@ MCP_DEBUG=false
 # ========== 图像生成配置 ==========
 # 图像保存目录配置
 MCP_IMAGE_SAVE_DIR=./generated_images
+# 对外可访问的基础地址（用于生成 images[].url）
+# 例如：https://mcp.your-domain.com
+# 当 MCP_HOST=0.0.0.0 或经反向代理发布时，建议显式设置
+# MCP_PUBLIC_BASE_URL=https://mcp.your-domain.com
 
 # 腾讯混元 API 配置
 # 获取地址: https://console.cloud.tencent.com/cam/capi

--- a/.env.test
+++ b/.env.test
@@ -39,6 +39,7 @@ MCP_DEBUG=true
 # ========== 测试图像保存目录 ==========
 # 使用独立的测试目录，不污染生产数据
 MCP_IMAGE_SAVE_DIR=./test_generated_images
+# MCP_PUBLIC_BASE_URL=http://127.0.0.1:8000
 
 # ========== API 凭据 ==========
 # ⚠️ 不要在此文件中填写真实的 API keys！

--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ Create a `.env` file in the project root. See `.env.example` for all available o
 ```bash
 # Image save directory
 MCP_IMAGE_SAVE_DIR=./generated_images
+# Public base URL for generated image links (HTTP mode, optional but recommended)
+# MCP_PUBLIC_BASE_URL=https://mcp.your-domain.com
 
 # API Provider Credentials (configure at least one)
 TENCENT_SECRET_ID=your_tencent_secret_id
@@ -185,6 +187,11 @@ Server will start on `http://127.0.0.1:8000` with endpoints:
 - `POST /mcp/v1/messages` - Send JSON-RPC messages
 - `GET /mcp/v1/messages` - Subscribe to SSE events
 - `DELETE /mcp/v1/messages` - Close session
+- `GET /images/{filename}` - Serve generated image files
+
+`generate_image` tool returns `images[].url` for HTTP clients.  
+If server is exposed through reverse proxy/public domain, set `MCP_PUBLIC_BASE_URL` to ensure URL is externally reachable.
+`/images/*` is intentionally public so browser/front-end image rendering works even when MCP API auth is enabled.
 
 #### 3. Test HTTP Server
 ```bash
@@ -598,5 +605,3 @@ We welcome contributions of all kinds! Here are some ways you can help:
 Please make sure to update tests as appropriate and follow the existing coding style.
 
 > We appreciate your interest in making this project better!
-
-

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -99,6 +99,8 @@ pip install -r requirements.lock.txt
 ```bash
 # 图像保存目录
 MCP_IMAGE_SAVE_DIR=./generated_images
+# 生成图片外链的公网基础地址（HTTP 模式，可选但推荐）
+# MCP_PUBLIC_BASE_URL=https://mcp.your-domain.com
 
 # API 提供商凭证（至少配置一个）
 TENCENT_SECRET_ID=你的腾讯云SecretId
@@ -183,6 +185,11 @@ python -m mcp_image_server
 - `POST /mcp/v1/messages` - 发送 JSON-RPC 消息
 - `GET /mcp/v1/messages` - 订阅 SSE 事件
 - `DELETE /mcp/v1/messages` - 关闭会话
+- `GET /images/{filename}` - 提供已生成图片的静态访问
+
+`generate_image` 工具会返回 `images[].url`（HTTP 客户端）。  
+如果服务通过反向代理或公网域名对外，请设置 `MCP_PUBLIC_BASE_URL`，保证返回 URL 可被外部访问。
+为保证浏览器/前端渲染，`/images/*` 默认对外开放（即使启用了 MCP API Bearer 认证）。
 
 #### 3. 测试 HTTP 服务器
 ```bash
@@ -617,4 +624,3 @@ python test_mcp_server.py --with-api
 请确保适当更新测试，并遵循现有的代码风格。
 
 > 感谢您对改进这个项目的关注！
-

--- a/docs/HTTP_TRANSPORT_GUIDE.md
+++ b/docs/HTTP_TRANSPORT_GUIDE.md
@@ -178,6 +178,7 @@ python example_http_client.py generate
 | 环境变量 | 默认值 | 说明 |
 |---------|--------|------|
 | `MCP_IMAGE_SAVE_DIR` | `./generated_images` | 图像保存目录 |
+| `MCP_PUBLIC_BASE_URL` | `None` | 生成图片外链的基础地址（建议公网部署时设置） |
 
 #### API 提供商配置
 
@@ -205,6 +206,8 @@ MCP_HOST=127.0.0.1
 MCP_PORT=8000
 MCP_DEBUG=true
 MCP_LOG_LEVEL=DEBUG
+# 本地直接访问可不设置，默认按 host:port 生成 URL
+# MCP_PUBLIC_BASE_URL=http://127.0.0.1:8000
 
 # 禁用认证（本地开发）
 # MCP_AUTH_TOKEN=
@@ -221,6 +224,8 @@ MCP_HOST=0.0.0.0  # 监听所有接口
 MCP_PORT=8000
 MCP_DEBUG=false
 MCP_LOG_LEVEL=INFO
+# 通过公网域名/反向代理访问时必须设置，确保 images[].url 可外部访问
+MCP_PUBLIC_BASE_URL=https://mcp.your-domain.com
 
 # 启用认证（必需）
 MCP_AUTH_TOKEN=your-secure-random-token-here
@@ -247,6 +252,9 @@ OPENAI_API_KEY=${OPENAI_API_KEY}  # 从密钥管理器读取
 | `POST` | `/mcp/v1/messages` | 发送 JSON-RPC 消息 |
 | `GET` | `/mcp/v1/messages` | 订阅 SSE 事件流 |
 | `DELETE` | `/mcp/v1/messages` | 删除会话 |
+| `GET` | `/images/{filename}` | 访问已生成图片文件 |
+
+说明：`/images/*` 默认不要求 Bearer Token，便于前端直接渲染图片 URL。
 
 ### 1. 健康检查
 
@@ -468,7 +476,7 @@ Mcp-Session-Id: 550e8400-e29b-41d4-a716-446655440000
           "mime_type": "image/png",
           "file_name": "cat_openai_1707304800.png",
           "local_path": "/abs/path/generated_images/cat_openai_1707304800.png",
-          "url": null,
+          "url": "https://mcp.your-domain.com/images/cat_openai_1707304800.png",
           "size_bytes": 1543210,
           "revised_prompt": null,
           "save_error": null
@@ -479,7 +487,7 @@ Mcp-Session-Id: 550e8400-e29b-41d4-a716-446655440000
     "content": [
       {
         "type": "text",
-        "text": "{\"version\":\"1.0\",\"ok\":true,\"images\":[{\"id\":\"img_openai_1707304800\",\"provider\":\"openai\",\"mime_type\":\"image/png\",\"file_name\":\"cat_openai_1707304800.png\",\"local_path\":\"/abs/path/generated_images/cat_openai_1707304800.png\",\"url\":null,\"size_bytes\":1543210,\"revised_prompt\":null,\"save_error\":null}],\"error\":null}"
+        "text": "{\"version\":\"1.0\",\"ok\":true,\"images\":[{\"id\":\"img_openai_1707304800\",\"provider\":\"openai\",\"mime_type\":\"image/png\",\"file_name\":\"cat_openai_1707304800.png\",\"local_path\":\"/abs/path/generated_images/cat_openai_1707304800.png\",\"url\":\"https://mcp.your-domain.com/images/cat_openai_1707304800.png\",\"size_bytes\":1543210,\"revised_prompt\":null,\"save_error\":null}],\"error\":null}"
       },
       {
         "type": "image",
@@ -490,6 +498,10 @@ Mcp-Session-Id: 550e8400-e29b-41d4-a716-446655440000
   }
 }
 ```
+
+说明：
+- 当 `MCP_PUBLIC_BASE_URL` 已配置时，`images[].url` 会使用该地址生成外部可访问链接。
+- 未配置时会尝试使用 `http://<MCP_HOST>:<MCP_PORT>`；若 `MCP_HOST=0.0.0.0` 或 `::`，则 `images[].url` 可能为 `null`。
 
 **响应（失败）:**
 
@@ -729,6 +741,8 @@ curl -X POST http://127.0.0.1:8000/mcp/v1/messages \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{...}}'
 ```
+
+注意：`/images/*` 静态图片路由默认不要求 `Authorization`，用于支持浏览器直接加载 `images[].url`。
 
 ### 安全最佳实践
 

--- a/examples/example_http_client.py
+++ b/examples/example_http_client.py
@@ -264,6 +264,7 @@ class MCPHTTPClient:
                     print(f"✅ 图像生成成功！")
                     print(f"   provider: {image.get('provider')}")
                     print(f"   local_path: {image.get('local_path')}")
+                    print(f"   url: {image.get('url')}")
                     print(f"   mime_type: {image.get('mime_type')}")
                     if image.get("save_error"):
                         print(f"   ⚠️ save_error: {image.get('save_error')}")

--- a/tests/test_http_image_urls.py
+++ b/tests/test_http_image_urls.py
@@ -1,0 +1,153 @@
+import base64
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from starlette.testclient import TestClient
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = PROJECT_ROOT / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from mcp_image_server.config import ServerConfig
+from mcp_image_server.transports.http_server import MCPImageServerHTTP
+
+
+class _FakeProvider:
+    def validate_style(self, style: str) -> bool:
+        return True
+
+    def validate_resolution(self, resolution: str) -> bool:
+        return True
+
+    def get_available_styles(self) -> dict:
+        return {"default": "default"}
+
+    def get_available_resolutions(self) -> dict:
+        return {"1024x1024": "1024x1024"}
+
+
+class _FakeProviderManager:
+    def __init__(self):
+        self.default_provider = "fake"
+        self._provider = _FakeProvider()
+
+    def get_provider(self, provider_name: str):
+        if provider_name == "fake":
+            return self._provider
+        return None
+
+    def get_available_providers(self):
+        return ["fake"]
+
+    async def generate_images(self, query: str, provider_name: str, **kwargs):
+        image_data = base64.b64encode(b"fake-image-bytes").decode("ascii")
+        return [
+            {
+                "content": image_data,
+                "content_type": "image/png",
+                "revised_prompt": None,
+            }
+        ]
+
+
+class HTTPImageURLTests(unittest.IsolatedAsyncioTestCase):
+    async def test_generate_image_populates_public_url(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = ServerConfig(
+                transport="http",
+                host="127.0.0.1",
+                port=8123,
+                image_save_dir=tmpdir,
+                public_base_url="https://mcp.example.com",
+            )
+            server = MCPImageServerHTTP(config)
+            server.provider_manager = _FakeProviderManager()
+
+            result = await server._generate_image(prompt="test prompt")
+
+            self.assertTrue(result.get("ok"))
+            self.assertEqual(len(result.get("images", [])), 1)
+
+            image = result["images"][0]
+            self.assertIsNotNone(image.get("local_path"))
+            self.assertTrue(Path(image["local_path"]).exists())
+            self.assertEqual(
+                image.get("url"),
+                f"https://mcp.example.com/images/{image.get('file_name')}",
+            )
+
+    async def test_generate_image_url_is_none_for_wildcard_host_without_public_base(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = ServerConfig(
+                transport="http",
+                host="0.0.0.0",
+                port=8123,
+                image_save_dir=tmpdir,
+            )
+            server = MCPImageServerHTTP(config)
+            server.provider_manager = _FakeProviderManager()
+
+            result = await server._generate_image(prompt="test prompt")
+
+            self.assertTrue(result.get("ok"))
+            image = result["images"][0]
+            self.assertIsNone(image.get("url"))
+
+
+class HTTPStaticRouteTests(unittest.TestCase):
+    def test_images_static_route_is_mounted(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = ServerConfig(
+                transport="http",
+                host="127.0.0.1",
+                port=8123,
+                image_save_dir=tmpdir,
+            )
+            server = MCPImageServerHTTP(config)
+            app = server.create_app()
+
+            image_route_paths = [route.path for route in app.routes]
+            self.assertIn("/images", image_route_paths)
+
+    def test_url_builder_uses_host_port_when_public_base_missing(self):
+        config = ServerConfig(
+            transport="http",
+            host="127.0.0.1",
+            port=8123,
+            image_save_dir="./generated_images",
+        )
+        server = MCPImageServerHTTP(config)
+        url = server._build_public_image_url("demo.png")
+        self.assertEqual(url, "http://127.0.0.1:8123/images/demo.png")
+
+    def test_images_route_is_public_even_when_auth_enabled(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            image_path = Path(tmpdir) / "demo.png"
+            image_bytes = b"png-bytes"
+            image_path.write_bytes(image_bytes)
+
+            config = ServerConfig(
+                transport="http",
+                host="127.0.0.1",
+                port=8123,
+                image_save_dir=tmpdir,
+                auth_token="test-token",
+            )
+            server = MCPImageServerHTTP(config)
+            app = server.create_app()
+
+            with TestClient(app) as client:
+                image_response = client.get("/images/demo.png")
+                self.assertEqual(image_response.status_code, 200)
+                self.assertEqual(image_response.content, image_bytes)
+
+                mcp_response = client.get("/mcp/v1/messages")
+                self.assertEqual(mcp_response.status_code, 401)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- add MCP_PUBLIC_BASE_URL config and validation

- mount /images static route and populate images[].url

- allow /images* without auth for frontend rendering

- update docs/examples and add URL regression tests