### PR TITLE
feat(mcp): add get_image_data tool for programmable base64 retrieval

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,6 +59,10 @@ MCP_IMAGE_SAVE_DIR=./generated_images
 # 例如：https://mcp.your-domain.com
 # 当 MCP_HOST=0.0.0.0 或经反向代理发布时，建议显式设置
 # MCP_PUBLIC_BASE_URL=https://mcp.your-domain.com
+# get_image_data 元数据缓存保留时间（秒）
+# MCP_IMAGE_RECORD_TTL=86400
+# get_image_data 单次返回的最大图片字节数（默认10MB）
+# MCP_GET_IMAGE_DATA_MAX_BYTES=10485760
 
 # 腾讯混元 API 配置
 # 获取地址: https://console.cloud.tencent.com/cam/capi

--- a/.env.test
+++ b/.env.test
@@ -40,6 +40,8 @@ MCP_DEBUG=true
 # 使用独立的测试目录，不污染生产数据
 MCP_IMAGE_SAVE_DIR=./test_generated_images
 # MCP_PUBLIC_BASE_URL=http://127.0.0.1:8000
+MCP_IMAGE_RECORD_TTL=86400
+MCP_GET_IMAGE_DATA_MAX_BYTES=10485760
 
 # ========== API 凭据 ==========
 # ⚠️ 不要在此文件中填写真实的 API keys！

--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ Create a `.env` file in the project root. See `.env.example` for all available o
 MCP_IMAGE_SAVE_DIR=./generated_images
 # Public base URL for generated image links (HTTP mode, optional but recommended)
 # MCP_PUBLIC_BASE_URL=https://mcp.your-domain.com
+# Metadata TTL for get_image_data cache (seconds)
+# MCP_IMAGE_RECORD_TTL=86400
+# Max bytes allowed in get_image_data base64 response
+# MCP_GET_IMAGE_DATA_MAX_BYTES=10485760
 
 # API Provider Credentials (configure at least one)
 TENCENT_SECRET_ID=your_tencent_secret_id
@@ -193,6 +197,10 @@ Server will start on `http://127.0.0.1:8000` with endpoints:
 If server is exposed through reverse proxy/public domain, set `MCP_PUBLIC_BASE_URL` to ensure URL is externally reachable.
 `/images/*` is intentionally public so browser/front-end image rendering works even when MCP API auth is enabled.
 
+Best-practice agent flow:
+1. Call `generate_image` to get renderable image + stable `image_id`/`url`.
+2. Call `get_image_data(image_id=...)` only when programmable base64 text is required.
+
 #### 3. Test HTTP Server
 ```bash
 # Check server health
@@ -228,6 +236,7 @@ You can connect from MCP-compatible client(recommand cursor now). The server pro
 
 #### Tools
 - `generate_image` - Generate images based on prompt, style, and resolution
+- `get_image_data` - Fetch base64 text for a previously generated image by `image_id`
 
 #### Prompts
 - `image_generation_prompt` - Create image generation prompt templates

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -101,6 +101,10 @@ pip install -r requirements.lock.txt
 MCP_IMAGE_SAVE_DIR=./generated_images
 # 生成图片外链的公网基础地址（HTTP 模式，可选但推荐）
 # MCP_PUBLIC_BASE_URL=https://mcp.your-domain.com
+# get_image_data 元数据缓存 TTL（秒）
+# MCP_IMAGE_RECORD_TTL=86400
+# get_image_data 返回 base64 时允许的最大字节数
+# MCP_GET_IMAGE_DATA_MAX_BYTES=10485760
 
 # API 提供商凭证（至少配置一个）
 TENCENT_SECRET_ID=你的腾讯云SecretId
@@ -191,6 +195,10 @@ python -m mcp_image_server
 如果服务通过反向代理或公网域名对外，请设置 `MCP_PUBLIC_BASE_URL`，保证返回 URL 可被外部访问。
 为保证浏览器/前端渲染，`/images/*` 默认对外开放（即使启用了 MCP API Bearer 认证）。
 
+推荐的 Agent 调用链路：
+1. 先调 `generate_image`，获取可渲染图片与稳定 `image_id`/`url`。
+2. 仅在需要“可编程 base64 文本”时再调 `get_image_data(image_id=...)`。
+
 #### 3. 测试 HTTP 服务器
 ```bash
 # 检查服务器健康状态
@@ -227,6 +235,7 @@ MCP 服务器成功运行截图：
 
 #### 工具
 - `generate_image` - 根据提示词、风格、分辨率生成图片
+- `get_image_data` - 按 `image_id` 获取已生成图片的 base64 文本
 
 #### 提示模板
 - `image_generation_prompt` - 生成图片请求的标准提示模板

--- a/src/mcp_image_server/config.py
+++ b/src/mcp_image_server/config.py
@@ -100,6 +100,18 @@ class ServerConfig(BaseSettings):
         validation_alias=AliasChoices('MCP_PUBLIC_BASE_URL', 'public_base_url')
     )
 
+    image_record_ttl: int = Field(
+        default=86400,
+        description="Image metadata cache TTL in seconds for get_image_data tool",
+        validation_alias=AliasChoices('MCP_IMAGE_RECORD_TTL', 'image_record_ttl')
+    )
+
+    get_image_data_max_bytes: int = Field(
+        default=10 * 1024 * 1024,
+        description="Maximum image size in bytes allowed for get_image_data base64 response",
+        validation_alias=AliasChoices('MCP_GET_IMAGE_DATA_MAX_BYTES', 'get_image_data_max_bytes')
+    )
+
     # ========== Provider Configuration ==========
     # Tencent Hunyuan
     tencent_secret_id: Optional[str] = Field(
@@ -245,6 +257,12 @@ class ServerConfig(BaseSettings):
                         f"got: {self.public_base_url}"
                     )
 
+            if self.image_record_ttl <= 0:
+                raise ValueError("MCP_IMAGE_RECORD_TTL must be greater than 0")
+
+            if self.get_image_data_max_bytes <= 0:
+                raise ValueError("MCP_GET_IMAGE_DATA_MAX_BYTES must be greater than 0")
+
     def __str__(self) -> str:
         """String representation of config (safe, no secrets)."""
         return (
@@ -253,6 +271,8 @@ class ServerConfig(BaseSettings):
             f"port={self.port if self.is_http_transport() else 'N/A'}, "
             f"auth_enabled={self.auth_enabled()}, "
             f"public_base_url={'configured' if self.public_base_url else 'auto'}, "
+            f"image_record_ttl={self.image_record_ttl}, "
+            f"get_image_data_max_bytes={self.get_image_data_max_bytes}, "
             f"providers={list(self.get_provider_credentials().keys())})"
         )
 


### PR DESCRIPTION
- keep generate_image lightweight and render-friendly

- add image metadata cache with TTL and safe path checks

- add size guard via MCP_GET_IMAGE_DATA_MAX_BYTES

- update docs/env examples and extend regression tests