### PR TITLE
Feature/http transport support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,10 @@ MCP_IMAGE_SAVE_DIR=./generated_images
 # get_image_data 单次返回的最大图片字节数（默认10MB）
 # MCP_GET_IMAGE_DATA_MAX_BYTES=10485760
 
+# 默认提供商（可选，配置多个 provider 时强烈建议设置）
+# 可选值：hunyuan / openai / doubao
+# MCP_DEFAULT_PROVIDER=openai
+
 # 腾讯混元 API 配置
 # 获取地址: https://console.cloud.tencent.com/cam/capi
 TENCENT_SECRET_ID=your_tencent_secret_id_here
@@ -73,15 +77,17 @@ TENCENT_SECRET_KEY=your_tencent_secret_key_here
 # 获取地址: https://platform.openai.com/account/api-keys
 OPENAI_API_KEY=your_openai_api_key_here
 # OPENAI_BASE_URL=https://api.openai.com/v1  # 可选，用于自定义端点
+# OPENAI_MODEL=gpt-image-1.5  # 可选，模型版本（默认 gpt-image-1.5，支持 gpt-image-1 / gpt-image-1-mini）
 
 # 豆包 API 配置（字节跳动 Ark 平台）
 # 获取地址: https://www.volcengine.com/docs/82379/1541523
 # 注意：豆包已迁移到 Ark API，使用 API Key 认证（不再使用 AK/SK）
 DOUBAO_API_KEY=your_doubao_api_key_here
 # DOUBAO_ENDPOINT=https://ark.cn-beijing.volces.com  # 可选，自定义端点
-# DOUBAO_MODEL=doubao-seedream-4.0  # 可选，模型版本（默认 4.0，可选 4.5）
+# DOUBAO_MODEL=doubao-seedream-4.5  # 可选，主模型（默认 4.5）
+# DOUBAO_FALLBACK_MODEL=doubao-seedream-4.0  # 可选，主模型不可用时回退（默认 4.0）
 
 # 注意：
 # - 你不需要配置所有的API密钥，只需要配置你想使用的API即可
-# - 系统会自动检测已配置的API并选择可用的提供者
+# - 若配置了多个 provider，建议设置 MCP_DEFAULT_PROVIDER 以避免隐式默认行为
 # - 至少需要配置一个API提供者才能正常使用服务

--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,8 @@ poetry.lock
 # VSCode/Cursor
 .vscode/
 .cursor/
+.claude/
+.codex/
 
 # OS files
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MCP Image Generation Server
 
-A Model Context Protocol (MCP) server for image generation using multiple AI providers including Tencent Hunyuan, OpenAI DALL-E 3, and Doubao APIs.
+A Model Context Protocol (MCP) server for image generation using multiple AI providers including Tencent Hunyuan, OpenAI GPT Image, and Doubao APIs.
 
 **Version**: 0.2.0
 
@@ -8,7 +8,7 @@ A Model Context Protocol (MCP) server for image generation using multiple AI pro
 
 ### 🎯 Multi-API Provider Support
 - **Tencent Hunyuan**: 18 artistic styles with Chinese optimization
-- **OpenAI DALL-E 3**: High-quality image generation with English optimization
+- **OpenAI GPT Image**: High-quality image generation with English optimization
 - **Doubao (ByteDance)**: Balanced quality and speed with 12 styles
 
 ### 🚀 Core Features
@@ -112,8 +112,9 @@ MCP_IMAGE_SAVE_DIR=./generated_images
 TENCENT_SECRET_ID=your_tencent_secret_id
 TENCENT_SECRET_KEY=your_tencent_secret_key
 OPENAI_API_KEY=your_openai_api_key
-DOUBAO_ACCESS_KEY=your_doubao_access_key
-DOUBAO_SECRET_KEY=your_doubao_secret_key
+DOUBAO_API_KEY=your_doubao_api_key
+# Optional but recommended when multiple providers are configured
+# MCP_DEFAULT_PROVIDER=openai
 ```
 
 #### Transport Configuration (Optional)
@@ -288,9 +289,9 @@ generate_image(
 - **Resolutions**: 8 options from `768:768` to `1280:720`
 - **Specialty**: Chinese-optimized, rich artistic styles
 
-#### OpenAI DALL-E 3
+#### OpenAI GPT Image
 - **Styles**: 12 options including `natural`, `vivid`, `realistic`, `artistic`, `anime`
-- **Resolutions**: 7 options including ultra-high resolution `1792x1024`
+- **Resolutions**: 3 options: `1024x1024`, `1536x1024`, `1024x1536`
 - **Specialty**: High-quality output, English optimization
 
 #### Doubao (ByteDance)
@@ -320,7 +321,7 @@ To add this MCP server in Cursor:
       "type": "stdio",
       "command": "D:\\your_path\\image-gen-mcp-server\\.venv\\Scripts\\python.exe",
       "args": ["-m", "mcp_image_server"],
-      "environment": ["TENCENT_SECRET_ID", "TENCENT_SECRET_KEY", "OPENAI_API_KEY", "DOUBAO_API_KEY", "MCP_IMAGE_SAVE_DIR"],
+      "environment": ["TENCENT_SECRET_ID", "TENCENT_SECRET_KEY", "OPENAI_API_KEY", "DOUBAO_API_KEY", "MCP_DEFAULT_PROVIDER", "MCP_IMAGE_SAVE_DIR"],
       "autoRestart": true,
       "startupTimeoutMs": 30000
     }
@@ -343,13 +344,16 @@ When configuring the MCP server in Cursor, set the following environment variabl
 - `TENCENT_SECRET_ID`: Your Tencent Cloud API Secret ID
 - `TENCENT_SECRET_KEY`: Your Tencent Cloud API Secret Key
 - `OPENAI_API_KEY`: Your OpenAI API Key
-- `DOUBAO_ACCESS_KEY`: Your Doubao Access Key
-- `DOUBAO_SECRET_KEY`: Your Doubao Secret Key
+- `DOUBAO_API_KEY`: Your Doubao API Key (Ark)
 - `MCP_IMAGE_SAVE_DIR`: Your save image dir, e.g.: D:\data\mcp_img
 - `OPENAI_BASE_URL`: (Optional) Custom OpenAI endpoint
+- `OPENAI_MODEL`: (Optional) OpenAI image model, default: `gpt-image-1.5`
 - `DOUBAO_ENDPOINT`: (Optional) Custom Doubao endpoint
+- `DOUBAO_MODEL`: (Optional) Doubao primary model, default: `doubao-seedream-4.5`
+- `DOUBAO_FALLBACK_MODEL`: (Optional) Doubao fallback model, default: `doubao-seedream-4.0`
+- `MCP_DEFAULT_PROVIDER`: (Optional but recommended when multiple providers are enabled) default provider to use when request does not specify one. Allowed: `hunyuan`, `openai`, `doubao`
 
-**Note**: You only need to configure the API keys for the providers you want to use. The system will automatically detect available providers.
+**Note**: You only need to configure providers you want to use. When multiple providers are configured, set `MCP_DEFAULT_PROVIDER` to avoid implicit routing order. After changing `.env` model/default-provider settings at runtime, call `reload_config` to apply without restart (or restart server if you changed non hot-reloadable fields like `MCP_PORT`).
 
 ### 🎯 Multi-API Usage in Cursor
 
@@ -484,7 +488,7 @@ The project now supports multiple image generation APIs through a unified interf
 
 #### Supported APIs
 1. **Tencent Hunyuan Image Generation API** (Original)
-2. **OpenAI DALL-E 3 API** (New)
+2. **OpenAI GPT Image API** (New)
 3. **Doubao Image Generation API** (New)
 
 #### Unified MCP Resources
@@ -496,6 +500,8 @@ The project now supports multiple image generation APIs through a unified interf
 
 #### Enhanced MCP Tools
 - `generate_image` - Multi-provider image generation with intelligent routing
+- `get_image_data` - Retrieve base64 text data for a generated image by id
+- `reload_config` - Reload runtime config/models from env/.env without process restart (safe subset only)
 
 ### Tencent Hunyuan Image Generation API
 
@@ -516,7 +522,7 @@ For detailed API documentation and pricing, please refer to:
 - [API Documentation](https://cloud.tencent.com/document/api/1729/105970)
 - [Pricing Details](https://cloud.tencent.com/document/product/1729/105925) 
 
-### OpenAI DALL-E 3 API
+### OpenAI GPT Image API
 
 #### API Features
 - High-quality image generation
@@ -536,7 +542,7 @@ For detailed API documentation and pricing, please refer to:
 
 - **Version 0.2.0** (Current)
   - ✅ Tencent Hunyuan image generation API
-  - ✅ OpenAI DALL-E 3 API integration
+  - ✅ OpenAI GPT Image API integration
   - ✅ Doubao API integration
   - ✅ Multi-provider management system
   - ✅ Intelligent provider selection

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,6 +1,6 @@
 # MCP 图像生成服务
 
-一个基于 Model Context Protocol (MCP) 的图像生成服务，支持多个主流AI提供商，包括腾讯混元、OpenAI DALL-E 3 和豆包 API。
+一个基于 Model Context Protocol (MCP) 的图像生成服务，支持多个主流AI提供商，包括腾讯混元、OpenAI GPT Image 和豆包 API。
 
 **版本**: 0.2.0
 
@@ -8,7 +8,7 @@
 
 ### 🎯 多API提供商支持
 - **腾讯混元**: 18种艺术风格，中文优化
-- **OpenAI DALL-E 3**: 高质量图像生成，英文优化
+- **OpenAI GPT Image**: 高质量图像生成，英文优化
 - **豆包（字节跳动）**: 平衡的质量和速度，12种风格
 
 ### 🚀 核心功能
@@ -110,8 +110,9 @@ MCP_IMAGE_SAVE_DIR=./generated_images
 TENCENT_SECRET_ID=你的腾讯云SecretId
 TENCENT_SECRET_KEY=你的腾讯云SecretKey
 OPENAI_API_KEY=你的OpenAI密钥
-DOUBAO_ACCESS_KEY=你的豆包AccessKey
-DOUBAO_SECRET_KEY=你的豆包SecretKey
+DOUBAO_API_KEY=你的豆包API Key
+# 可选但推荐：当配置多个 provider 时设置默认提供商
+# MCP_DEFAULT_PROVIDER=openai
 ```
 
 #### 传输配置（可选）
@@ -287,9 +288,9 @@ generate_image(
 - **分辨率**: 8种选项，从 `768:768` 到 `1280:720`
 - **特色**: 中文优化，丰富的艺术风格
 
-#### OpenAI DALL-E 3
+#### OpenAI GPT Image
 - **风格**: 12种选项，包括 `natural`、`vivid`、`realistic`、`artistic`、`anime`
-- **分辨率**: 7种选项，包括超高分辨率 `1792x1024`
+- **分辨率**: 3种选项：`1024x1024`、`1536x1024`、`1024x1536`
 - **特色**: 高质量输出，英文优化
 
 #### 豆包（字节跳动）
@@ -339,8 +340,8 @@ generate_image(
         "TENCENT_SECRET_ID", 
         "TENCENT_SECRET_KEY",
         "OPENAI_API_KEY",
-        "DOUBAO_ACCESS_KEY",
-        "DOUBAO_SECRET_KEY",
+        "DOUBAO_API_KEY",
+        "MCP_DEFAULT_PROVIDER",
         "MCP_IMAGE_SAVE_DIR"
       ],
       "autoRestart": true,
@@ -363,13 +364,16 @@ generate_image(
 - `TENCENT_SECRET_ID`: 你的腾讯云 API Secret ID
 - `TENCENT_SECRET_KEY`: 你的腾讯云 API Secret Key
 - `OPENAI_API_KEY`: 你的 OpenAI API 密钥
-- `DOUBAO_ACCESS_KEY`: 你的豆包 Access Key
-- `DOUBAO_SECRET_KEY`: 你的豆包 Secret Key
+- `DOUBAO_API_KEY`: 你的豆包 API Key（Ark）
 - `MCP_IMAGE_SAVE_DIR`: 图片保存的位置，例如: D:\data\mcp_img
 - `OPENAI_BASE_URL`: （可选）自定义 OpenAI 端点
+- `OPENAI_MODEL`: （可选）OpenAI 生图模型，默认：`gpt-image-1.5`
 - `DOUBAO_ENDPOINT`: （可选）自定义豆包端点
+- `DOUBAO_MODEL`: （可选）豆包主模型，默认：`doubao-seedream-4.5`
+- `DOUBAO_FALLBACK_MODEL`: （可选）豆包回退模型，默认：`doubao-seedream-4.0`
+- `MCP_DEFAULT_PROVIDER`: （可选但推荐，尤其是多 provider 场景）请求未指定 provider 时默认使用哪个。可选：`hunyuan`、`openai`、`doubao`
 
-**注意**: 你只需要配置想要使用的提供商的API密钥。系统会自动检测可用的提供商。
+**注意**: 你只需要配置想要使用的提供商。若配置了多个 provider，建议设置 `MCP_DEFAULT_PROVIDER`，避免隐式路由顺序。运行中修改 `.env` 模型/默认提供商配置后，可调用 `reload_config` 热更新生效；如果修改了 `MCP_PORT` 等非热更新项，仍需要重启服务。
 
 ### 🎯 在Cursor中使用多API
 
@@ -493,7 +497,7 @@ python test_mcp_server.py --with-api
 
 #### 支持的API
 1. **腾讯混元图像生成API**（原版）
-2. **OpenAI DALL-E 3 API**（新增）
+2. **OpenAI GPT Image API**（新增）
 3. **豆包图像生成API**（新增）
 
 #### 统一MCP资源
@@ -505,6 +509,8 @@ python test_mcp_server.py --with-api
 
 #### 增强的MCP工具
 - `generate_image` - 具有智能路由的多提供商图像生成
+- `get_image_data` - 通过图片 id 获取已生成图片的 base64 文本数据
+- `reload_config` - 无需重启进程重载运行时配置/模型（仅支持安全子集）
 
 ### 腾讯混元生图 API
 
@@ -525,7 +531,7 @@ python test_mcp_server.py --with-api
 - [API 文档](https://cloud.tencent.com/document/api/1729/105970)
 - [计费说明](https://cloud.tencent.com/document/product/1729/105925)
 
-### OpenAI DALL-E 3 API
+### OpenAI GPT Image API
 
 #### API特性
 - 高质量图像生成
@@ -545,7 +551,7 @@ python test_mcp_server.py --with-api
 
 - **v0.2.0 版本**（当前）
   - ✅ 腾讯混元图像生成API
-  - ✅ OpenAI DALL-E 3 API集成
+  - ✅ OpenAI GPT Image API集成
   - ✅ 豆包API集成
   - ✅ 多提供商管理系统
   - ✅ 智能提供商选择

--- a/src/mcp_image_server/providers/doubao_provider.py
+++ b/src/mcp_image_server/providers/doubao_provider.py
@@ -9,11 +9,23 @@ from .base import BaseImageProvider, debug_print
 class DoubaoProvider(BaseImageProvider):
     """ByteDance Doubao (豆包) image generation provider using Ark API"""
 
-    def __init__(self, api_key: str, endpoint: Optional[str] = None, model: str = "doubao-seedream-4.0", **kwargs):
+    def __init__(
+        self,
+        api_key: str,
+        model: str,
+        endpoint: Optional[str] = None,
+        fallback_model: Optional[str] = None,
+        **kwargs
+    ):
         super().__init__(**kwargs)
         self.api_key = api_key
         self.endpoint = endpoint or "https://ark.cn-beijing.volces.com"
-        self.model = model  # doubao-seedream-4.0, doubao-seedream-4.5, etc.
+        self.model = model.strip()
+        if not self.model:
+            raise ValueError("Doubao model must be provided via DOUBAO_MODEL")
+        self.fallback_model = (fallback_model or "").strip() or None
+        if self.fallback_model == self.model:
+            self.fallback_model = None
 
     def get_provider_name(self) -> str:
         return "doubao"
@@ -40,7 +52,7 @@ class DoubaoProvider(BaseImageProvider):
 
     def get_available_resolutions(self) -> Dict[str, str]:
         """
-        Doubao Seedream 4.0/4.5 supported resolutions.
+        Doubao Seedream models supported resolutions.
         Format: WIDTHxHEIGHT
         """
         return {
@@ -55,6 +67,74 @@ class DoubaoProvider(BaseImageProvider):
             "1024x768": "1024x768 (4:3 横向)"
         }
 
+    @staticmethod
+    def _is_model_unavailable_error(error_text: str) -> bool:
+        text = (error_text or "").lower()
+        if not text:
+            return False
+
+        model_tokens = ("model", "模型")
+        unavailable_tokens = (
+            "unsupported",
+            "not found",
+            "does not exist",
+            "invalid",
+            "unavailable",
+            "not available",
+            "not enabled",
+            "unknown model",
+            "未开通",
+            "不存在",
+            "不支持",
+            "不可用",
+            "非法",
+            "无权限",
+        )
+        return any(token in text for token in model_tokens) and any(
+            token in text for token in unavailable_tokens
+        )
+
+    async def _request_generation(
+        self,
+        session: aiohttp.ClientSession,
+        model: str,
+        prompt: str,
+        size: str,
+        negative_prompt: str,
+        headers: Dict[str, str],
+    ) -> tuple[Optional[Dict], int, str]:
+        request_data = {
+            "model": model,
+            "prompt": prompt,
+            "n": 1,
+            "size": size,
+            "response_format": "b64_json",
+        }
+        if negative_prompt:
+            request_data["negative_prompt"] = negative_prompt
+
+        async with session.post(
+            f"{self.endpoint}/api/v3/images/generations",
+            headers=headers,
+            json=request_data,
+            timeout=aiohttp.ClientTimeout(total=60),
+        ) as response:
+            status_code = response.status
+
+            if status_code != 200:
+                return None, status_code, await response.text()
+
+            response_data = await response.json()
+            if "error" in response_data:
+                error_payload = response_data["error"]
+                if isinstance(error_payload, dict):
+                    error_text = error_payload.get("message") or json.dumps(error_payload, ensure_ascii=False)
+                else:
+                    error_text = str(error_payload)
+                return None, status_code, error_text
+
+            return response_data, status_code, ""
+
     async def generate_images(
         self,
         query: str,
@@ -65,7 +145,10 @@ class DoubaoProvider(BaseImageProvider):
     ) -> List[Dict]:
         """Generate images using Doubao Ark API"""
         try:
-            debug_print(f"[DEBUG] Doubao generate_images call started: query={query}, style={style}, resolution={resolution}, model={self.model}")
+            debug_print(
+                f"[DEBUG] Doubao generate_images call started: query={query}, style={style}, "
+                f"resolution={resolution}, model={self.model}, fallback_model={self.fallback_model}"
+            )
 
             # Parse resolution
             width, height = map(int, resolution.split('x'))
@@ -79,53 +162,44 @@ class DoubaoProvider(BaseImageProvider):
                     english_part = style_desc.split()[-1] if " " in style_desc else style_desc
                     full_prompt = f"{query}, {english_part}"
 
-            # Prepare request data (Ark API format, similar to OpenAI)
-            request_data = {
-                "model": self.model,
-                "prompt": full_prompt,
-                "n": 1,  # Number of images to generate
-                "size": f"{width}x{height}",
-                "response_format": "b64_json"  # Return base64 encoded image
-            }
-
-            # Add negative prompt if provided
-            if negative_prompt:
-                request_data["negative_prompt"] = negative_prompt
-
             # Prepare headers
             headers = {
                 "Content-Type": "application/json",
                 "Authorization": f"Bearer {self.api_key}"
             }
 
+            models_to_try = [self.model]
+            if self.fallback_model:
+                models_to_try.append(self.fallback_model)
+
             debug_print(f"[DEBUG] Calling Doubao Ark API with prompt: {full_prompt}")
-
-            # Make API request
             async with aiohttp.ClientSession() as session:
-                async with session.post(
-                    f"{self.endpoint}/api/v3/images/generations",
-                    headers=headers,
-                    json=request_data,
-                    timeout=aiohttp.ClientTimeout(total=60)
-                ) as response:
+                for index, model_name in enumerate(models_to_try):
+                    response_data, status_code, error_text = await self._request_generation(
+                        session=session,
+                        model=model_name,
+                        prompt=full_prompt,
+                        size=f"{width}x{height}",
+                        negative_prompt=negative_prompt,
+                        headers=headers,
+                    )
 
-                    if response.status != 200:
-                        error_text = await response.text()
-                        debug_print(f"[ERROR] Doubao API request failed with status {response.status}: {error_text}")
+                    if response_data is None:
+                        debug_print(
+                            f"[ERROR] Doubao API request failed: model={model_name}, "
+                            f"status={status_code}, error={error_text}"
+                        )
+
+                        has_fallback = index == 0 and len(models_to_try) > 1
+                        if has_fallback and self._is_model_unavailable_error(error_text):
+                            debug_print(
+                                f"[WARNING] Doubao model '{model_name}' unavailable, "
+                                f"retrying with fallback '{models_to_try[1]}'"
+                            )
+                            continue
+
                         return [{
-                            "error": f"Doubao API request failed: HTTP {response.status}",
-                            "content_type": "text/plain"
-                        }]
-
-                    response_data = await response.json()
-                    debug_print(f"[DEBUG] Doubao API response received")
-
-                    # Check for API errors
-                    if "error" in response_data:
-                        error_msg = response_data["error"].get("message", "Unknown error from Doubao API")
-                        debug_print(f"[ERROR] Doubao API error: {error_msg}")
-                        return [{
-                            "error": f"Doubao API error: {error_msg}",
+                            "error": f"Doubao API request failed: HTTP {status_code}, {error_text}",
                             "content_type": "text/plain"
                         }]
 
@@ -136,6 +210,8 @@ class DoubaoProvider(BaseImageProvider):
                             "error": "No image data returned from Doubao API",
                             "content_type": "text/plain"
                         }]
+
+                    debug_print(f"[DEBUG] Doubao API response received with model={model_name}")
 
                     # Get first image (we requested n=1)
                     image_item = response_data["data"][0]
@@ -166,14 +242,19 @@ class DoubaoProvider(BaseImageProvider):
                     # Return result
                     result = [{
                         "content": encoded_image,
-                        "content_type": "image/png",  # Ark API typically returns PNG
+                        "content_type": "image/png",
                         "description": query,
                         "style": style,
                         "provider": self.get_provider_name()
                     }]
 
-                    debug_print(f"[DEBUG] Returning Doubao result successfully")
+                    debug_print(f"[DEBUG] Returning Doubao result successfully with model={model_name}")
                     return result
+
+                return [{
+                    "error": "Doubao API request failed after trying all configured models",
+                    "content_type": "text/plain"
+                }]
 
         except asyncio.TimeoutError:
             error_msg = "Doubao API request timeout"

--- a/src/mcp_image_server/providers/hunyuan_provider.py
+++ b/src/mcp_image_server/providers/hunyuan_provider.py
@@ -1,6 +1,6 @@
 from tencentcloud.common import credential
 from tencentcloud.common.exception.tencent_cloud_sdk_exception import TencentCloudSDKException
-from tencentcloud.hunyuan.v20230901 import hunyuan_client, models
+from tencentcloud.aiart.v20221229 import aiart_client, models as aiart_models
 import json
 import base64
 from typing import Dict, List, Optional
@@ -10,84 +10,104 @@ import sys
 from .base import BaseImageProvider, debug_print
 
 class HunyuanProvider(BaseImageProvider):
-    """Tencent Hunyuan image generation provider"""
-    
+    """Tencent HunyuanImage 3.0 image generation provider"""
+
     def __init__(self, secret_id: str, secret_key: str, **kwargs):
         super().__init__(**kwargs)
         self.cred = credential.Credential(secret_id, secret_key)
-        self.client = hunyuan_client.HunyuanClient(self.cred, "ap-guangzhou")
-    
+        self.client = aiart_client.AiartClient(self.cred, "ap-guangzhou")
+
     def get_provider_name(self) -> str:
         return "hunyuan"
-    
+
+    @staticmethod
+    def _extract_result_image_url(result_image: object) -> Optional[str]:
+        """Extract a usable image URL from Tencent ResultImage payload."""
+        if isinstance(result_image, str):
+            return result_image if result_image else None
+
+        if isinstance(result_image, list):
+            for item in result_image:
+                if isinstance(item, str) and item:
+                    return item
+
+        return None
+
     def get_available_styles(self) -> Dict[str, str]:
+        # HunyuanImage 3.0 has no Style parameter; styles are injected into the prompt
         return {
-            "riman": "日漫动画",
-            "xieshi": "写实",
-            "monai": "莫奈画风",
-            "shuimo": "水墨画",
-            "bianping": "扁平插画",
-            "xiangsu": "像素插画",
-            "ertonghuiben": "儿童绘本",
-            "3dxuanran": "3D渲染",
-            "manhua": "漫画",
-            "heibaimanhua": "黑白漫画",
-            "dongman": "动漫",
-            "bijiasuo": "毕加索",
-            "saibopengke": "赛博朋克",
-            "youhua": "油画",
-            "masaike": "马赛克",
-            "qinghuaci": "青花瓷",
-            "xinnianjianzhi": "新年剪纸画",
-            "xinnianhuayi": "新年花艺"
+            "riman": "日漫动画风格, Japanese anime style",
+            "xieshi": "写实风格, photorealistic style",
+            "monai": "莫奈印象派画风, Monet impressionist painting style",
+            "shuimo": "水墨画风格, Chinese ink wash painting style",
+            "bianping": "扁平插画风格, flat illustration style",
+            "xiangsu": "像素插画风格, pixel art style",
+            "ertonghuiben": "儿童绘本风格, children's picture book style",
+            "3dxuanran": "3D渲染风格, 3D rendering style",
+            "manhua": "漫画风格, comic style",
+            "heibaimanhua": "黑白漫画风格, black and white comic style",
+            "dongman": "动漫风格, animation style",
+            "bijiasuo": "毕加索立体主义风格, Picasso cubism style",
+            "saibopengke": "赛博朋克风格, cyberpunk style",
+            "youhua": "油画风格, oil painting style",
+            "masaike": "马赛克风格, mosaic style",
+            "qinghuaci": "青花瓷风格, blue and white porcelain style",
+            "xinnianjianzhi": "新年剪纸画风格, New Year paper-cut art style",
+            "xinnianhuayi": "新年花艺风格, New Year floral art style"
         }
-    
+
     def get_available_resolutions(self) -> Dict[str, str]:
+        # HunyuanImage 3.0: width and height each in [512, 2048], width*height <= 1024*1024
         return {
-            "768:768": "768:768(1:1 正方形)",
-            "768:1024": "768:1024(3:4 竖向)",
-            "1024:768": "1024:768(4:3 横向)",
-            "1024:1024": "1024:1024(1:1 正方形大图)",
-            "720:1280": "720:1280(16:9 竖向)",
-            "1280:720": "1280:720(9:16 横向)",
-            "768:1280": "768:1280(3:5 竖向)",
-            "1280:768": "1280:768(5:3 横向)"
+            "768:768": "768:768 (1:1 正方形)",
+            "768:1024": "768:1024 (3:4 竖向)",
+            "1024:768": "1024:768 (4:3 横向)",
+            "1024:1024": "1024:1024 (1:1 正方形大图)",
+            "720:1280": "720:1280 (9:16 竖向)",  # 720*1280=921600 <= 1024*1024=1048576
+            "1280:720": "1280:720 (16:9 横向)",
+            "512:1024": "512:1024 (1:2 竖向)",
+            "1024:512": "1024:512 (2:1 横向)"
         }
-    
+
     async def generate_images(
-        self, 
-        query: str, 
+        self,
+        query: str,
         style: str = "riman",
         resolution: str = "1024:1024",
         negative_prompt: str = "",
         **kwargs
     ) -> List[Dict]:
-        """Generate images using Hunyuan text-to-image model"""
+        """Generate images using HunyuanImage 3.0 text-to-image model"""
         try:
             debug_print(f"[DEBUG] Hunyuan generate_images call started: query={query}, style={style}, resolution={resolution}")
-            
+
+            # Build prompt: inject style description and negative prompt
+            styled_prompt = query
+            if style:
+                style_desc = self.get_available_styles().get(style, "")
+                if style_desc:
+                    styled_prompt = f"{query}, {style_desc}"
+
+            if negative_prompt:
+                styled_prompt = f"{styled_prompt}. Avoid: {negative_prompt}"
+
             # Create request object
-            req = models.SubmitHunyuanImageJobRequest()
-            
-            # Set request parameters
-            req.Prompt = query
-            req.Style = style
+            req = aiart_models.SubmitTextToImageJobRequest()
+            req.Prompt = styled_prompt
             req.Resolution = resolution
-            req.Num = 1  # Default generate 1 image
             req.Revise = 1  # Enable prompt expansion
             req.LogoAdd = 0  # No watermark
-            
-            if negative_prompt:
-                req.NegativePrompt = negative_prompt
-            
-            debug_print(f"[DEBUG] Calling Tencent API SubmitHunyuanImageJob: Prompt={query}, Style={style}, Resolution={resolution}")
-            
-            # Try to call interface, retry on failure
+
+            debug_print(f"[DEBUG] Calling Tencent API SubmitTextToImageJob: Prompt={styled_prompt}, Resolution={resolution}")
+
+            loop = asyncio.get_event_loop()
+
+            # Try to submit job, retry on failure
             job_id = None
             max_retries = 3
             for attempt in range(max_retries):
                 try:
-                    resp = self.client.SubmitHunyuanImageJob(req)
+                    resp = await loop.run_in_executor(None, self.client.SubmitTextToImageJob, req)
                     job_id = resp.JobId
                     debug_print(f"[DEBUG] Successfully submitted task, JobId={job_id}")
                     break
@@ -95,38 +115,36 @@ class HunyuanProvider(BaseImageProvider):
                     error_msg = str(e)
                     debug_print(f"[ERROR] Task submission failed (attempt {attempt+1}/{max_retries}): {error_msg}")
                     if attempt < max_retries - 1:
-                        await asyncio.sleep(2)  # Wait 2 seconds before retrying
+                        await asyncio.sleep(2)
                     else:
-                        raise  # Retry count exhausted, continue to throw exception
-            
+                        raise
+
             if not job_id:
                 debug_print("[ERROR] Unable to get task ID")
                 return [{
                     "error": "Failed to create image generation task",
                     "content_type": "text/plain"
                 }]
-            
+
             # Wait for task completion and get results
             image_result = await self._wait_for_job_completion(job_id)
-            
+
             if image_result is None:
                 debug_print("[ERROR] Image generation failed, returning empty result")
                 return [{
                     "error": "Image generation failed, unable to get image result",
                     "content_type": "text/plain"
                 }]
-            
+
             debug_print(f"[DEBUG] Image generation successful: image_url={image_result.get('url', 'No URL')}")
-            
-            # Check image data
+
             if not image_result.get("image_data"):
                 debug_print("[ERROR] Image data is empty")
                 return [{
                     "error": "Image data is empty",
                     "content_type": "text/plain"
                 }]
-            
-            # Ensure image data is properly encoded
+
             try:
                 encoded_image = base64.b64encode(image_result["image_data"]).decode('utf-8')
                 debug_print(f"[DEBUG] Image successfully encoded to base64, length: {len(encoded_image)}")
@@ -137,8 +155,7 @@ class HunyuanProvider(BaseImageProvider):
                     "error": f"Image encoding failed: {error_msg}",
                     "content_type": "text/plain"
                 }]
-            
-            # Return result containing all necessary fields
+
             result = [{
                 "content": encoded_image,
                 "content_type": "image/jpeg",
@@ -147,9 +164,9 @@ class HunyuanProvider(BaseImageProvider):
                 "provider": self.get_provider_name()
             }]
             debug_print(f"[DEBUG] Returning result: {result[0].keys()}")
-            
+
             return result
-            
+
         except TencentCloudSDKException as err:
             error_msg = str(err)
             debug_print(f"[ERROR] Failed to generate image: {error_msg}, Error type: {type(err)}")
@@ -166,33 +183,32 @@ class HunyuanProvider(BaseImageProvider):
                 "error": f"Error occurred during Hunyuan image generation: {error_msg}",
                 "content_type": "text/plain"
             }]
-    
+
     async def _wait_for_job_completion(self, job_id: str, max_retries: int = 60) -> Optional[Dict]:
         """Wait for task completion and get results"""
         try:
             debug_print(f"[DEBUG] Start waiting for task completion, JobId={job_id}, max_retries={max_retries}")
+            loop = asyncio.get_event_loop()
+
             for attempt in range(max_retries):
-                req = models.QueryHunyuanImageJobRequest()
+                req = aiart_models.QueryTextToImageJobRequest()
                 req.JobId = job_id
-                
+
                 debug_print(f"[DEBUG] Query task status, attempt #{attempt+1}, JobId={job_id}")
                 try:
-                    resp = self.client.QueryHunyuanImageJob(req)
-                    # Print response content for debugging
+                    resp = await loop.run_in_executor(None, self.client.QueryTextToImageJob, req)
                     debug_print(f"[DEBUG] Task status response: {resp.to_json_string()}")
-                    
-                    # Check task status code
+
                     status_code = resp.JobStatusCode
                     debug_print(f"[DEBUG] Task status code: {status_code}")
-                    
-                    if status_code == "5":   # 1: Waiting, 2: Running, 4: Processing failed, 5: Processing completed.
-                        if resp.ResultImage and len(resp.ResultImage) > 0:
-                            image_url = resp.ResultImage[0]
-                            debug_print(f"[DEBUG] Image generation completed, ResultImage: {resp.ResultImage}")
+
+                    if status_code == "5":   # 1: Waiting, 2: Running, 4: Failed, 5: Completed
+                        image_url = self._extract_result_image_url(resp.ResultImage)
+                        if image_url:
+                            debug_print(f"[DEBUG] Image generation completed, ResultImage: {image_url}")
                             debug_print(f"[DEBUG] Start downloading image: {image_url}")
-                            
-                            # Add retry logic for downloading images
-                            for download_attempt in range(3):  # Try downloading 3 times
+
+                            for download_attempt in range(3):
                                 image_data = await self._download_image(image_url)
                                 if image_data:
                                     debug_print(f"[DEBUG] Image download successful, size: {len(image_data)} bytes")
@@ -203,23 +219,26 @@ class HunyuanProvider(BaseImageProvider):
                                 else:
                                     debug_print(f"[WARNING] Image download failed, attempt #{download_attempt+1}/3")
                                     await asyncio.sleep(1)
-                            
+
                             debug_print("[ERROR] Image download failed, maximum retry count reached")
                             return None
                         else:
-                            debug_print("[ERROR] Task completed but no image result")
+                            debug_print(
+                                f"[ERROR] Task completed but no usable image result, "
+                                f"ResultImage={resp.ResultImage!r}"
+                            )
                             return None
                     elif status_code == "4":  # Processing failed
                         debug_print("[ERROR] Task processing failed")
                         return None
                     else:
                         debug_print(f"[DEBUG] Task still in progress, status code: {status_code}, waiting...")
-                        await asyncio.sleep(2)  # Wait 2 seconds before checking again
+                        await asyncio.sleep(2)
                 except TencentCloudSDKException as e:
                     error_msg = str(e)
                     debug_print(f"[ERROR] Error querying task status: {error_msg}")
-                    await asyncio.sleep(2)  # Wait 2 seconds before retrying
-            
+                    await asyncio.sleep(2)
+
             debug_print(f"[ERROR] Task not completed after {max_retries} retries")
             return None
         except Exception as e:
@@ -228,7 +247,7 @@ class HunyuanProvider(BaseImageProvider):
             import traceback
             traceback.print_exc(file=sys.stderr)
             return None
-    
+
     async def _download_image(self, url: str) -> Optional[bytes]:
         """Download image from URL"""
         debug_print(f"[DEBUG] Downloading image from URL: {url}")

--- a/src/mcp_image_server/providers/openai_provider.py
+++ b/src/mcp_image_server/providers/openai_provider.py
@@ -8,22 +8,31 @@ import sys
 from .base import BaseImageProvider, debug_print
 
 class OpenAIProvider(BaseImageProvider):
-    """OpenAI DALL-E image generation provider"""
-    
-    def __init__(self, api_key: str, base_url: Optional[str] = None, **kwargs):
+    """OpenAI image generation provider (GPT Image series)"""
+
+    def __init__(self, api_key: str, model: str, base_url: Optional[str] = None, **kwargs):
         super().__init__(**kwargs)
         self.client = openai.AsyncOpenAI(
             api_key=api_key,
             base_url=base_url
         )
-    
+        self.model = model.strip()
+        if not self.model:
+            raise ValueError("OpenAI model must be provided via OPENAI_MODEL")
+        if not self.model.startswith("gpt-image"):
+            raise ValueError(
+                "Unsupported OpenAI image model. "
+                "Only GPT Image models are supported (for example: gpt-image-1.5). "
+                f"Got: {self.model}"
+            )
+
     def get_provider_name(self) -> str:
         return "openai"
-    
+
     def get_available_styles(self) -> Dict[str, str]:
         return {
             "natural": "自然风格",
-            "vivid": "生动风格", 
+            "vivid": "生动风格",
             "realistic": "写实风格",
             "artistic": "艺术风格",
             "cartoon": "卡通风格",
@@ -35,87 +44,78 @@ class OpenAIProvider(BaseImageProvider):
             "photographic": "摄影风格",
             "minimalist": "极简风格"
         }
-    
+
     def get_available_resolutions(self) -> Dict[str, str]:
         return {
             "1024x1024": "1024x1024 (1:1 正方形)",
-            "1024x1792": "1024x1792 (9:16 竖向)",
-            "1792x1024": "1792x1024 (16:9 横向)",
-            "1344x768": "1344x768 (7:4 横向)", 
-            "768x1344": "768x1344 (4:7 竖向)",
             "1536x1024": "1536x1024 (3:2 横向)",
             "1024x1536": "1024x1536 (2:3 竖向)"
         }
-    
+
     async def generate_images(
-        self, 
-        query: str, 
+        self,
+        query: str,
         style: str = "natural",
         resolution: str = "1024x1024",
         negative_prompt: str = "",
         **kwargs
     ) -> List[Dict]:
-        """Generate images using OpenAI DALL-E"""
+        """Generate images using OpenAI image generation API"""
         try:
-            debug_print(f"[DEBUG] OpenAI generate_images call started: query={query}, style={style}, resolution={resolution}")
-            
+            debug_print(f"[DEBUG] OpenAI generate_images call started: model={self.model}, query={query}, style={style}, resolution={resolution}")
+
             # Prepare the prompt with style
             styled_prompt = query
             if style and style != "natural":
                 style_desc = self.get_available_styles().get(style, style)
                 styled_prompt = f"{query}, {style_desc}"
-            
-            # Add negative prompt handling (OpenAI doesn't directly support negative prompts, so we modify the main prompt)
+
             if negative_prompt:
                 styled_prompt = f"{styled_prompt}. Avoid: {negative_prompt}"
-            
-            debug_print(f"[DEBUG] Calling OpenAI DALL-E API with prompt: {styled_prompt}")
-            
-            # Make API call
+
+            debug_print(f"[DEBUG] Calling OpenAI API with model={self.model}, prompt: {styled_prompt}")
+
+            # GPT Image models: no legacy DALL-E style/response_format parameters.
             response = await self.client.images.generate(
-                model="dall-e-3",  # Use DALL-E 3 for better quality
+                model=self.model,
                 prompt=styled_prompt,
                 size=resolution,
-                quality="standard",  # Can be "standard" or "hd"
-                style="natural",     # OpenAI's built-in style parameter
-                response_format="b64_json",  # Get base64 directly
+                quality="auto",
                 n=1
             )
-            
+
             debug_print(f"[DEBUG] OpenAI API call successful")
-            
+
             if not response.data:
                 debug_print("[ERROR] No image data returned from OpenAI")
                 return [{
                     "error": "No image data returned from OpenAI API",
                     "content_type": "text/plain"
                 }]
-            
-            # Get the first (and only) image
+
             image_data = response.data[0]
-            
+
             if not image_data.b64_json:
                 debug_print("[ERROR] No base64 image data in response")
                 return [{
                     "error": "No base64 image data in OpenAI response",
                     "content_type": "text/plain"
                 }]
-            
+
             debug_print(f"[DEBUG] Image successfully generated, base64 length: {len(image_data.b64_json)}")
-            
-            # Return result
+
             result = [{
                 "content": image_data.b64_json,
-                "content_type": "image/png",  # DALL-E typically returns PNG
+                "content_type": "image/png",
                 "description": query,
                 "style": style,
                 "provider": self.get_provider_name(),
-                "revised_prompt": getattr(image_data, 'revised_prompt', None)  # OpenAI may revise the prompt
+                "revised_prompt": getattr(image_data, 'revised_prompt', None)
             }]
-            
+
             debug_print(f"[DEBUG] Returning OpenAI result: {result[0].keys()}")
             return result
-            
+
         except openai.RateLimitError as e:
             error_msg = f"OpenAI API rate limit exceeded: {str(e)}"
             debug_print(f"[ERROR] {error_msg}")

--- a/src/mcp_image_server/providers/provider_manager.py
+++ b/src/mcp_image_server/providers/provider_manager.py
@@ -1,33 +1,30 @@
-import os
 from typing import Dict, Optional, List
-from dotenv import load_dotenv
 from .base import BaseImageProvider, debug_print
 from .hunyuan_provider import HunyuanProvider
 from .openai_provider import OpenAIProvider
 from .doubao_provider import DoubaoProvider
-
-# Load .env file to make environment variables available via os.getenv()
-load_dotenv()
+from ..config import ServerConfig
 
 class ProviderManager:
     """Manages multiple image generation API providers"""
-    
-    def __init__(self):
+
+    SUPPORTED_PROVIDERS = frozenset({"hunyuan", "openai", "doubao"})
+
+    def __init__(self, config: Optional[ServerConfig] = None):
+        self.config = config or ServerConfig()
         self.providers: Dict[str, BaseImageProvider] = {}
         self.default_provider: Optional[str] = None
         self._initialize_providers()
-    
+
     def _initialize_providers(self):
-        """Initialize available providers based on environment variables"""
-        
+        """Initialize available providers based on parsed server config."""
+
         # Initialize Hunyuan provider
-        tencent_secret_id = os.getenv("TENCENT_SECRET_ID")
-        tencent_secret_key = os.getenv("TENCENT_SECRET_KEY")
-        if tencent_secret_id and tencent_secret_key:
+        if self.config.tencent_secret_id and self.config.tencent_secret_key:
             try:
                 self.providers["hunyuan"] = HunyuanProvider(
-                    secret_id=tencent_secret_id,
-                    secret_key=tencent_secret_key
+                    secret_id=self.config.tencent_secret_id,
+                    secret_key=self.config.tencent_secret_key
                 )
                 debug_print("[INFO] Hunyuan provider initialized successfully")
                 # Set as default if no default is set
@@ -37,46 +34,80 @@ class ProviderManager:
                 debug_print(f"[ERROR] Failed to initialize Hunyuan provider: {e}")
         
         # Initialize OpenAI provider
-        openai_api_key = os.getenv("OPENAI_API_KEY")
-        openai_base_url = os.getenv("OPENAI_BASE_URL")  # Optional custom base URL
-        if openai_api_key:
-            try:
-                self.providers["openai"] = OpenAIProvider(
-                    api_key=openai_api_key,
-                    base_url=openai_base_url
-                )
-                debug_print("[INFO] OpenAI provider initialized successfully")
-                # Set as default if no default is set
-                if not self.default_provider:
-                    self.default_provider = "openai"
-            except Exception as e:
-                debug_print(f"[ERROR] Failed to initialize OpenAI provider: {e}")
-        
+        if self.config.openai_api_key:
+            openai_model = self.config.openai_model.strip()
+            if not openai_model:
+                debug_print("[WARNING] OPENAI_MODEL is empty. Skipping OpenAI provider initialization.")
+            else:
+                try:
+                    self.providers["openai"] = OpenAIProvider(
+                        api_key=self.config.openai_api_key,
+                        base_url=self.config.openai_base_url,
+                        model=openai_model
+                    )
+                    debug_print("[INFO] OpenAI provider initialized successfully")
+                    # Set as default if no default is set
+                    if not self.default_provider:
+                        self.default_provider = "openai"
+                except Exception as e:
+                    debug_print(f"[ERROR] Failed to initialize OpenAI provider: {e}")
+
         # Initialize Doubao provider (New Ark API)
-        doubao_api_key = os.getenv("DOUBAO_API_KEY")
-        doubao_endpoint = os.getenv("DOUBAO_ENDPOINT")  # Optional custom endpoint
-        doubao_model = os.getenv("DOUBAO_MODEL", "doubao-seedream-4.0")  # Default to 4.0
-        if doubao_api_key:
-            try:
-                self.providers["doubao"] = DoubaoProvider(
-                    api_key=doubao_api_key,
-                    endpoint=doubao_endpoint,
-                    model=doubao_model
-                )
-                debug_print("[INFO] Doubao provider initialized successfully")
-                #Set as default if no default is set
-                if not self.default_provider:
-                    self.default_provider = "doubao"
-            except Exception as e:
-                debug_print(f"[ERROR] Failed to initialize Doubao provider: {e}")
-        
+        if self.config.doubao_api_key:
+            doubao_model = self.config.doubao_model.strip()
+            doubao_fallback_model = self.config.doubao_fallback_model.strip()
+            if not doubao_model:
+                debug_print("[WARNING] DOUBAO_MODEL is empty. Skipping Doubao provider initialization.")
+            else:
+                try:
+                    self.providers["doubao"] = DoubaoProvider(
+                        api_key=self.config.doubao_api_key,
+                        endpoint=self.config.doubao_endpoint,
+                        model=doubao_model,
+                        fallback_model=doubao_fallback_model or None
+                    )
+                    debug_print("[INFO] Doubao provider initialized successfully")
+                    #Set as default if no default is set
+                    if not self.default_provider:
+                        self.default_provider = "doubao"
+                except Exception as e:
+                    debug_print(f"[ERROR] Failed to initialize Doubao provider: {e}")
+
         # Check if any provider was initialized
         if not self.providers:
             debug_print("[WARNING] No image generation providers were initialized. Please check your environment variables.")
-        else:
+
+        configured_default_raw = getattr(self.config, "default_provider", None)
+        configured_default = (
+            configured_default_raw.strip().lower()
+            if isinstance(configured_default_raw, str)
+            else configured_default_raw
+        )
+        if configured_default == "":
+            configured_default = None
+        if configured_default:
+            if configured_default not in self.SUPPORTED_PROVIDERS:
+                raise ValueError(
+                    "Invalid MCP_DEFAULT_PROVIDER. "
+                    f"Supported values: {sorted(self.SUPPORTED_PROVIDERS)}; got: {configured_default!r}"
+                )
+            if configured_default not in self.providers:
+                raise ValueError(
+                    f"MCP_DEFAULT_PROVIDER={configured_default!r} is configured but unavailable. "
+                    f"Initialized providers: {sorted(self.providers.keys()) or 'none'}. "
+                    "Check API credentials and model settings."
+                )
+            self.default_provider = configured_default
+        elif len(self.providers) > 1:
+            debug_print(
+                "[WARNING] Multiple providers are initialized but MCP_DEFAULT_PROVIDER is not set. "
+                f"Using implicit default provider: {self.default_provider}"
+            )
+
+        if self.providers:
             debug_print(f"[INFO] Initialized providers: {list(self.providers.keys())}")
             debug_print(f"[INFO] Default provider: {self.default_provider}")
-    
+
     def get_provider(self, provider_name: Optional[str] = None) -> Optional[BaseImageProvider]:
         """Get a specific provider or the default provider"""
         if provider_name:
@@ -85,42 +116,42 @@ class ProviderManager:
             return self.providers.get(self.default_provider)
         else:
             return None
-    
+
     def get_available_providers(self) -> List[str]:
         """Get list of available provider names"""
         return list(self.providers.keys())
-    
+
     def get_all_styles(self) -> Dict[str, Dict[str, str]]:
         """Get styles from all providers"""
         all_styles = {}
         for provider_name, provider in self.providers.items():
             all_styles[provider_name] = provider.get_available_styles()
         return all_styles
-    
+
     def get_all_resolutions(self) -> Dict[str, Dict[str, str]]:
         """Get resolutions from all providers"""
         all_resolutions = {}
         for provider_name, provider in self.providers.items():
             all_resolutions[provider_name] = provider.get_available_resolutions()
         return all_resolutions
-    
+
     def validate_provider_style(self, provider_name: str, style: str) -> bool:
         """Validate if a style is supported by a specific provider"""
         provider = self.get_provider(provider_name)
         if provider:
             return provider.validate_style(style)
         return False
-    
+
     def validate_provider_resolution(self, provider_name: str, resolution: str) -> bool:
         """Validate if a resolution is supported by a specific provider"""
         provider = self.get_provider(provider_name)
         if provider:
             return provider.validate_resolution(resolution)
         return False
-    
+
     async def generate_images(
-        self, 
-        query: str, 
+        self,
+        query: str,
         provider_name: Optional[str] = None,
         style: str = "default",
         resolution: str = "1024:1024",
@@ -129,7 +160,7 @@ class ProviderManager:
     ) -> List[Dict]:
         """Generate images using the specified provider or default provider"""
         provider = self.get_provider(provider_name)
-        
+
         if not provider:
             available = ", ".join(self.get_available_providers())
             error_msg = f"Provider '{provider_name}' not available. Available providers: {available}"
@@ -138,7 +169,7 @@ class ProviderManager:
                 "error": error_msg,
                 "content_type": "text/plain"
             }]
-        
+
         debug_print(f"[INFO] Using provider: {provider.get_provider_name()}")
         return await provider.generate_images(
             query=query,

--- a/tests/test_doubao_fallback_logic.py
+++ b/tests/test_doubao_fallback_logic.py
@@ -1,0 +1,41 @@
+import sys
+import unittest
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = PROJECT_ROOT / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from mcp_image_server.providers.doubao_provider import DoubaoProvider
+
+
+class DoubaoFallbackLogicTests(unittest.TestCase):
+    def test_detects_model_unavailable_errors(self):
+        self.assertTrue(
+            DoubaoProvider._is_model_unavailable_error(
+                "Model doubao-seedream-4.5 is not enabled for this account"
+            )
+        )
+        self.assertTrue(
+            DoubaoProvider._is_model_unavailable_error(
+                "请求失败：模型暂未开通"
+            )
+        )
+
+    def test_ignores_non_model_errors(self):
+        self.assertFalse(DoubaoProvider._is_model_unavailable_error("rate limit exceeded"))
+        self.assertFalse(DoubaoProvider._is_model_unavailable_error("network timeout"))
+
+    def test_disables_fallback_when_same_as_primary(self):
+        provider = DoubaoProvider(
+            api_key="test-key",
+            model="doubao-seedream-4.5",
+            fallback_model="doubao-seedream-4.5",
+        )
+        self.assertIsNone(provider.fallback_model)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_http_reload_config.py
+++ b/tests/test_http_reload_config.py
@@ -1,0 +1,129 @@
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = PROJECT_ROOT / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from mcp_image_server.config import ServerConfig
+from mcp_image_server.transports.http_server import MCPImageServerHTTP
+
+
+class HTTPReloadConfigTests(unittest.IsolatedAsyncioTestCase):
+    def test_list_tools_includes_reload_config(self):
+        with patch.dict(
+            os.environ,
+            {
+                "MCP_TRANSPORT": "http",
+                "MCP_HOST": "127.0.0.1",
+                "MCP_PORT": "8000",
+                "OPENAI_API_KEY": "openai-test-key",
+                "OPENAI_MODEL": "gpt-image-test-a",
+                "DOUBAO_API_KEY": "doubao-test-key",
+                "DOUBAO_MODEL": "doubao-seedream-test-a",
+                "DOUBAO_FALLBACK_MODEL": "doubao-seedream-fallback-a",
+            },
+            clear=True,
+        ):
+            server = MCPImageServerHTTP(ServerConfig())
+            tools = self._run(server._list_tools())
+            tool_names = [tool.name for tool in tools]
+            self.assertIn("reload_config", tool_names)
+
+    async def test_reload_config_updates_provider_models(self):
+        with patch.dict(
+            os.environ,
+            {
+                "MCP_TRANSPORT": "http",
+                "MCP_HOST": "127.0.0.1",
+                "MCP_PORT": "8000",
+                "OPENAI_API_KEY": "openai-test-key",
+                "OPENAI_MODEL": "gpt-image-test-a",
+                "DOUBAO_API_KEY": "doubao-test-key",
+                "DOUBAO_MODEL": "doubao-seedream-test-a",
+                "DOUBAO_FALLBACK_MODEL": "doubao-seedream-fallback-a",
+                "MCP_DEFAULT_PROVIDER": "openai",
+            },
+            clear=True,
+        ):
+            server = MCPImageServerHTTP(ServerConfig())
+            self.assertEqual(server.provider_manager.get_provider("openai").model, "gpt-image-test-a")
+            self.assertEqual(server.provider_manager.get_provider("doubao").model, "doubao-seedream-test-a")
+            self.assertEqual(server.provider_manager.default_provider, "openai")
+
+            os.environ["OPENAI_MODEL"] = "gpt-image-test-b"
+            os.environ["DOUBAO_MODEL"] = "doubao-seedream-test-b"
+            os.environ["DOUBAO_FALLBACK_MODEL"] = "doubao-seedream-fallback-b"
+            os.environ["MCP_DEFAULT_PROVIDER"] = "doubao"
+
+            result = await server._reload_config(dotenv_override=False)
+
+            self.assertTrue(result.get("ok"), msg=result)
+            changed_fields = result["result"]["changed_fields"]
+            self.assertIn("openai_model", changed_fields)
+            self.assertIn("doubao_model", changed_fields)
+            self.assertIn("doubao_fallback_model", changed_fields)
+            self.assertIn("default_provider", changed_fields)
+            self.assertEqual(server.provider_manager.get_provider("openai").model, "gpt-image-test-b")
+            self.assertEqual(server.provider_manager.get_provider("doubao").model, "doubao-seedream-test-b")
+            self.assertEqual(
+                server.provider_manager.get_provider("doubao").fallback_model,
+                "doubao-seedream-fallback-b",
+            )
+            self.assertEqual(server.provider_manager.default_provider, "doubao")
+
+    async def test_reload_config_rejects_restart_required_changes(self):
+        with patch.dict(
+            os.environ,
+            {
+                "MCP_TRANSPORT": "http",
+                "MCP_HOST": "127.0.0.1",
+                "MCP_PORT": "8000",
+                "OPENAI_API_KEY": "openai-test-key",
+                "OPENAI_MODEL": "gpt-image-test-a",
+            },
+            clear=True,
+        ):
+            server = MCPImageServerHTTP(ServerConfig())
+            os.environ["MCP_PORT"] = "9000"
+
+            result = await server._reload_config(dotenv_override=False)
+
+            self.assertFalse(result.get("ok"), msg=result)
+            self.assertEqual(result["error"]["code"], "restart_required")
+            self.assertIn("port", result["error"]["details"]["restart_required_fields"])
+
+    async def test_reload_config_rejects_unavailable_default_provider(self):
+        with patch.dict(
+            os.environ,
+            {
+                "MCP_TRANSPORT": "http",
+                "MCP_HOST": "127.0.0.1",
+                "MCP_PORT": "8000",
+                "OPENAI_API_KEY": "openai-test-key",
+                "OPENAI_MODEL": "gpt-image-test-a",
+                "MCP_DEFAULT_PROVIDER": "openai",
+            },
+            clear=True,
+        ):
+            server = MCPImageServerHTTP(ServerConfig())
+            os.environ["MCP_DEFAULT_PROVIDER"] = "doubao"
+
+            result = await server._reload_config(dotenv_override=False)
+
+            self.assertFalse(result.get("ok"), msg=result)
+            self.assertEqual(result["error"]["code"], "invalid_config")
+
+    def _run(self, coro):
+        import asyncio
+
+        return asyncio.run(coro)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_hunyuan_provider_request_fields.py
+++ b/tests/test_hunyuan_provider_request_fields.py
@@ -1,0 +1,64 @@
+import asyncio
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = PROJECT_ROOT / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from mcp_image_server.providers.hunyuan_provider import HunyuanProvider
+
+
+class _StrictSubmitTextToImageJobRequest:
+    __slots__ = ("Prompt", "Resolution", "Revise", "LogoAdd")
+
+    def __init__(self):
+        self.Prompt = None
+        self.Resolution = None
+        self.Revise = None
+        self.LogoAdd = None
+
+
+class HunyuanProviderRequestFieldTests(unittest.TestCase):
+    def test_submit_request_only_uses_supported_fields(self):
+        fake_client = MagicMock()
+        fake_client.SubmitTextToImageJob.return_value = SimpleNamespace(JobId="job-123")
+
+        with patch("mcp_image_server.providers.hunyuan_provider.credential.Credential"), patch(
+            "mcp_image_server.providers.hunyuan_provider.aiart_client.AiartClient",
+            return_value=fake_client,
+        ), patch(
+            "mcp_image_server.providers.hunyuan_provider.aiart_models.SubmitTextToImageJobRequest",
+            _StrictSubmitTextToImageJobRequest,
+        ):
+            provider = HunyuanProvider(secret_id="sid", secret_key="skey")
+            with patch.object(
+                provider,
+                "_wait_for_job_completion",
+                AsyncMock(return_value={"image_data": b"fake-bytes", "url": "https://example.com/image.jpg"}),
+            ):
+                result = asyncio.run(
+                    provider.generate_images(
+                        query="a mountain",
+                        style="riman",
+                        resolution="1024:1024",
+                    )
+                )
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["provider"], "hunyuan")
+        self.assertEqual(result[0]["content_type"], "image/jpeg")
+
+        submit_request = fake_client.SubmitTextToImageJob.call_args.args[0]
+        self.assertEqual(submit_request.Resolution, "1024:1024")
+        self.assertEqual(submit_request.Revise, 1)
+        self.assertEqual(submit_request.LogoAdd, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_hunyuan_provider_result_image.py
+++ b/tests/test_hunyuan_provider_result_image.py
@@ -1,0 +1,33 @@
+import sys
+import unittest
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = PROJECT_ROOT / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from mcp_image_server.providers.hunyuan_provider import HunyuanProvider
+
+
+class HunyuanResultImageParsingTests(unittest.TestCase):
+    def test_extract_result_image_url_from_list(self):
+        url = HunyuanProvider._extract_result_image_url(
+            ["https://example.com/image-1.jpg", "https://example.com/image-2.jpg"]
+        )
+        self.assertEqual(url, "https://example.com/image-1.jpg")
+
+    def test_extract_result_image_url_from_string(self):
+        url = HunyuanProvider._extract_result_image_url("https://example.com/image-1.jpg")
+        self.assertEqual(url, "https://example.com/image-1.jpg")
+
+    def test_extract_result_image_url_handles_invalid_payload(self):
+        self.assertIsNone(HunyuanProvider._extract_result_image_url([]))
+        self.assertIsNone(HunyuanProvider._extract_result_image_url(["", None]))
+        self.assertIsNone(HunyuanProvider._extract_result_image_url(None))
+        self.assertIsNone(HunyuanProvider._extract_result_image_url({"url": "x"}))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_openai_provider_model_policy.py
+++ b/tests/test_openai_provider_model_policy.py
@@ -1,0 +1,56 @@
+import asyncio
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = PROJECT_ROOT / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from mcp_image_server.providers.openai_provider import OpenAIProvider
+
+
+class OpenAIProviderModelPolicyTests(unittest.TestCase):
+    def test_rejects_non_gpt_image_models(self):
+        with patch("mcp_image_server.providers.openai_provider.openai.AsyncOpenAI") as mock_async_openai:
+            mock_async_openai.return_value = MagicMock()
+            with self.assertRaises(ValueError):
+                OpenAIProvider(api_key="test-key", model="dall-e-3")
+
+    def test_gpt_image_request_uses_supported_parameters(self):
+        mock_client = MagicMock()
+        mock_client.images.generate = AsyncMock(
+            return_value=SimpleNamespace(
+                data=[SimpleNamespace(b64_json="ZmFrZV9pbWFnZQ==", revised_prompt=None)]
+            )
+        )
+
+        with patch("mcp_image_server.providers.openai_provider.openai.AsyncOpenAI", return_value=mock_client):
+            provider = OpenAIProvider(api_key="test-key", model="gpt-image-1.5")
+            result = asyncio.run(
+                provider.generate_images(
+                    query="a cat",
+                    style="natural",
+                    resolution="1024x1024",
+                    negative_prompt=""
+                )
+            )
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["provider"], "openai")
+        self.assertEqual(result[0]["content"], "ZmFrZV9pbWFnZQ==")
+
+        kwargs = mock_client.images.generate.await_args.kwargs
+        self.assertEqual(kwargs["model"], "gpt-image-1.5")
+        self.assertEqual(kwargs["size"], "1024x1024")
+        self.assertEqual(kwargs["quality"], "auto")
+        self.assertNotIn("style", kwargs)
+        self.assertNotIn("response_format", kwargs)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_provider_manager_config.py
+++ b/tests/test_provider_manager_config.py
@@ -1,0 +1,129 @@
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = PROJECT_ROOT / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from mcp_image_server.providers.provider_manager import ProviderManager
+
+
+class ProviderManagerConfigTests(unittest.TestCase):
+    @staticmethod
+    def _build_config(**overrides):
+        base = {
+            "default_provider": None,
+            "tencent_secret_id": None,
+            "tencent_secret_key": None,
+            "openai_api_key": None,
+            "openai_base_url": None,
+            "openai_model": "gpt-image-1.5",
+            "doubao_api_key": None,
+            "doubao_endpoint": None,
+            "doubao_model": "doubao-seedream-4.5",
+            "doubao_fallback_model": "doubao-seedream-4.0",
+        }
+        base.update(overrides)
+        return SimpleNamespace(**base)
+
+    def test_model_fields_are_injected_from_config(self):
+        config = self._build_config(
+            openai_api_key="openai-key",
+            openai_base_url="https://api.openai.com/v1",
+            openai_model="gpt-image-1.5",
+            doubao_api_key="doubao-key",
+            doubao_endpoint="https://ark.cn-beijing.volces.com",
+            doubao_model="doubao-seedream-4.5",
+            doubao_fallback_model="doubao-seedream-4.0",
+        )
+
+        with patch("mcp_image_server.providers.provider_manager.OpenAIProvider") as mock_openai, patch(
+            "mcp_image_server.providers.provider_manager.DoubaoProvider"
+        ) as mock_doubao:
+            mock_openai.return_value = MagicMock()
+            mock_doubao.return_value = MagicMock()
+
+            manager = ProviderManager(config=config)
+
+        mock_openai.assert_called_once_with(
+            api_key="openai-key",
+            base_url="https://api.openai.com/v1",
+            model="gpt-image-1.5",
+        )
+        mock_doubao.assert_called_once_with(
+            api_key="doubao-key",
+            endpoint="https://ark.cn-beijing.volces.com",
+            model="doubao-seedream-4.5",
+            fallback_model="doubao-seedream-4.0",
+        )
+        self.assertEqual(manager.default_provider, "openai")
+        self.assertEqual(sorted(manager.get_available_providers()), ["doubao", "openai"])
+
+    def test_empty_model_string_skips_provider_initialization(self):
+        config = self._build_config(
+            openai_api_key="openai-key",
+            openai_model="   ",
+            doubao_api_key="doubao-key",
+            doubao_model="",
+            doubao_fallback_model="doubao-seedream-4.0",
+        )
+
+        with patch("mcp_image_server.providers.provider_manager.OpenAIProvider") as mock_openai, patch(
+            "mcp_image_server.providers.provider_manager.DoubaoProvider"
+        ) as mock_doubao:
+            manager = ProviderManager(config=config)
+
+        mock_openai.assert_not_called()
+        mock_doubao.assert_not_called()
+        self.assertEqual(manager.get_available_providers(), [])
+        self.assertIsNone(manager.default_provider)
+
+    def test_configured_default_provider_overrides_implicit_order(self):
+        config = self._build_config(
+            default_provider="doubao",
+            openai_api_key="openai-key",
+            openai_model="gpt-image-1.5",
+            doubao_api_key="doubao-key",
+            doubao_model="doubao-seedream-4.5",
+            doubao_fallback_model="doubao-seedream-4.0",
+        )
+
+        with patch("mcp_image_server.providers.provider_manager.OpenAIProvider") as mock_openai, patch(
+            "mcp_image_server.providers.provider_manager.DoubaoProvider"
+        ) as mock_doubao:
+            mock_openai.return_value = MagicMock()
+            mock_doubao.return_value = MagicMock()
+            manager = ProviderManager(config=config)
+
+        self.assertEqual(sorted(manager.get_available_providers()), ["doubao", "openai"])
+        self.assertEqual(manager.default_provider, "doubao")
+
+    def test_invalid_or_unavailable_default_provider_fails_fast(self):
+        invalid_name_config = self._build_config(
+            default_provider="invalid-provider",
+            openai_api_key="openai-key",
+            openai_model="gpt-image-1.5",
+        )
+        with patch("mcp_image_server.providers.provider_manager.OpenAIProvider") as mock_openai:
+            mock_openai.return_value = MagicMock()
+            with self.assertRaises(ValueError):
+                ProviderManager(config=invalid_name_config)
+
+        unavailable_config = self._build_config(
+            default_provider="doubao",
+            openai_api_key="openai-key",
+            openai_model="gpt-image-1.5",
+        )
+        with patch("mcp_image_server.providers.provider_manager.OpenAIProvider") as mock_openai:
+            mock_openai.return_value = MagicMock()
+            with self.assertRaises(ValueError):
+                ProviderManager(config=unavailable_config)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
make provider/model config explicit and hot-reloadable

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core provider integrations and runtime configuration reloading, which can affect image generation correctness and production routing/default behavior. The new hot-reload path and provider API migrations increase the chance of runtime misconfiguration or subtle provider-specific regressions.
> 
> **Overview**
> **Makes provider/model configuration explicit and hot-reloadable across both HTTP and stdio transports.** Adds `MCP_DEFAULT_PROVIDER`, `OPENAI_MODEL`, `DOUBAO_MODEL`, and `DOUBAO_FALLBACK_MODEL` to `ServerConfig`, wires `ProviderManager` to initialize providers from parsed config (and fail fast on invalid/unavailable defaults), and introduces a new `reload_config` MCP tool (HTTP + stdio) that reloads a safe subset of settings with masking/diagnostics and rejects changes requiring restart.
> 
> Provider integrations are updated accordingly: OpenAI switches to GPT Image models with model validation and updated request parameters; Doubao adds primary+fallback model retry logic on “model unavailable” errors; Hunyuan migrates to the Tencent `aiart` (HunyuanImage 3.0) API, adjusting prompt/style handling and job polling. Docs and `.env.example` are updated to reflect the new env vars and provider naming, `.gitignore` ignores new IDE folders, and new unit tests cover reload behavior, model policies, and provider edge cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2638f504f0b244f0d8e76205880041ad88c7a9b7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->